### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_xacml_editor.info.yml
+++ b/islandora_xacml_editor.info.yml
@@ -6,5 +6,5 @@ dependencies:
 package: 'Islandora Tools'
 configure: islandora_xacml_editor.admin
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module

--- a/modules/islandora_xacml_api/islandora_xacml_api.info.yml
+++ b/modules/islandora_xacml_api/islandora_xacml_api.info.yml
@@ -5,5 +5,5 @@ dependencies:
 package: 'Islandora Tools'
 configure: islandora_xacml_api.admin
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)